### PR TITLE
Fix the repo links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # React Native Releases
 
-[![GitHub Issues](https://img.shields.io/github/issues/react-native-community/react-native-releases.svg)](https://github.com/react-native-community/react-native-releases/issues) ![Contributions welcome](https://img.shields.io/badge/contributions-welcome-orange.svg)
+[![GitHub Issues](https://img.shields.io/github/issues/react-native-community/releases.svg)](https://github.com/react-native-community/releases/issues) ![Contributions welcome](https://img.shields.io/badge/contributions-welcome-orange.svg)
 
-Stay up-to-date with the release activities of [React Native](https://github.com/facebook/react-native/) by [watching](https://github.com/react-native-community/react-native-releases/subscription) for [status reports](https://github.com/react-native-community/react-native-releases/issues?q=is%3Aopen+is%3Aissue+label%3A%22release+status%22). Or you can follow along as the release notes are prepared and help reviewing the overall [changelog](https://github.com/react-native-community/react-native-releases/blob/master/CHANGELOG.md).
+Stay up-to-date with the release activities of [React Native](https://github.com/facebook/react-native/) by [watching](https://github.com/react-native-community/releases/subscription) for [status reports](https://github.com/react-native-community/releases/issues?q=is%3Aopen+is%3Aissue+label%3A%22release+status%22). Or you can follow along as the release notes are prepared and help reviewing the overall [changelog](https://github.com/react-native-community/releases/blob/master/CHANGELOG.md).
 
 ## Release Status Issues
 


### PR DESCRIPTION
It looks like the repo was renamed. For the most part the redirects work, however, the badges were broken. This PR fixes them 👍 