### PR TITLE
Filter out internal commits from the changelog

### DIFF
--- a/changelog-generator.js
+++ b/changelog-generator.js
@@ -150,7 +150,7 @@ function isTurboModules(change) {
 }
 
 function isInternal(change) {
-  return /^\[internal\]/i.test(change);
+  return /\[internal\]/i.test(change);
 }
 
 function getChangeMessage(item) {
@@ -193,7 +193,7 @@ function getChangelogDesc(commits) {
 
     if(isFabric(change.split('\n')[0])) return;
     if(isTurboModules(change.split('\n')[0])) return;
-    if(isInternal(change.split('\n')[0])) return;
+    if(isInternal(change)) return;
 
     if (isAdded(change)) {
       if (isAndroidCommit(change)) {


### PR DESCRIPTION
Facebook employees have been tagging their commits with [Internal] in order to remove them from the changelog. This wasn't being picked up by the changelog generator. This is an example commit that wasn't being filtered: https://github.com/facebook/react-native/commit/40ee0ad

The commit summary is:
```
LogBox - Re-apply badge color fix

Summary:
The previous diff mistakenly landed an old version

Changelog: [Internal]
```

The script was only looking for [Internal] in `LogBox - Re-apply badge color fix`. Now it looks for it on any line. 

Before this change:
```
$ yarn generate -b 8c7ec519812c570535912c45dd81db51ba2fdd31 -c bdd1a675ba6949868d11ef0c3dccaa8f336ca384 | wc -l
284
```

After:
```
$ yarn generate -b 8c7ec519812c570535912c45dd81db51ba2fdd31 -c bdd1a675ba6949868d11ef0c3dccaa8f336ca384 | wc -l
154
```