### PR TITLE
Add a breaking changes section to the changelog

### DIFF
--- a/changelog-generator.js
+++ b/changelog-generator.js
@@ -150,7 +150,7 @@ function isTurboModules(change) {
 }
 
 function isInternal(change) {
-  return /^\[internal\]/i.test(change);
+  return /\[internal\]/i.test(change);
 }
 
 function getChangeMessage(item) {
@@ -193,7 +193,7 @@ function getChangelogDesc(commits) {
 
     if(isFabric(change.split('\n')[0])) return;
     if(isTurboModules(change.split('\n')[0])) return;
-    if(isInternal(change.split('\n')[0])) return;
+    if(isInternal(change)) return;
 
     if (isAdded(change)) {
       if (isAndroidCommit(change)) {

--- a/changelog-generator.js
+++ b/changelog-generator.js
@@ -117,6 +117,10 @@ function isIOSCommit(change) {
   );
 }
 
+function isBreaking(change) {
+  return /\b(breaking)\b/i.test(change);
+}
+
 function isAdded(change) {
   return /\b(added)\b/i.test(change);
 }
@@ -178,6 +182,7 @@ function getChangeMessage(item) {
 
 function getChangelogDesc(commits) {
   const acc = {
+    breaking: { android: [], ios: [], general: [] },
     added: { android: [], ios: [], general: [] },
     changed: { android: [], ios: [], general: [] },
     deprecated: { android: [], ios: [], general: [] },
@@ -195,7 +200,15 @@ function getChangelogDesc(commits) {
     if(isTurboModules(change.split('\n')[0])) return;
     if(isInternal(change)) return;
 
-    if (isAdded(change)) {
+    if (isBreaking(change)) {
+      if (isAndroidCommit(change)) {
+        acc.breaking.android.push(message);
+      } else if (isIOSCommit(change)) {
+        acc.breaking.ios.push(message);
+      } else {
+        acc.breaking.general.push(message);
+      }
+    } else if (isAdded(change)) {
       if (isAndroidCommit(change)) {
         acc.added.android.push(message);
       } else if (isIOSCommit(change)) {
@@ -261,6 +274,18 @@ function buildMarkDown(data) {
   return `
 
 ## [${argv.compare}.0]
+
+### Breaking
+
+${data.breaking.general.join("\n")}
+
+#### Android specific
+
+${data.breaking.android.join("\n")}
+
+#### iOS specific
+
+${data.breaking.ios.join("\n")}
 
 ### Added
 


### PR DESCRIPTION
*This PR is based on https://github.com/react-native-community/releases/pull/152 and thus includes those changes as well. Once that is merged this will get simplified*

This command now includes a breaking changes section
```
$ yarn generate -b 8c7ec519812c570535912c45dd81db51ba2fdd31 -c bdd1a675ba6949868d11ef0c3dccaa8f336ca384

## [bdd1a675ba6949868d11ef0c3dccaa8f336ca384.0]

### Breaking

- Animated: Remove `defaultProps` Parameter ([a70987c](https://github.com/facebook/react-native/commit/a70987c) by [@yungsters](https://github.com/yungsters))
- Remove TextInput's `inputView` prop ([1804e7c](https://github.com/facebook/react-native/commit/1804e7c) by [@TheSavior](https://github.com/TheSavior))
- Changelog: [General] [Changed] Split NativeImageLoader into NativeImageLoaderAndroid and NativeImageLoaderIOS ([d37baa7](https://github.com/facebook/react-native/commit/d37baa7) by [@ejanzer](https://github.com/ejanzer))
- Removing <TextInput>'s `onTextInput` event ([3f7e0a2](https://github.com/facebook/react-native/commit/3f7e0a2) by [@shergin](https://github.com/shergin))

#### Android specific



#### iOS specific



### Added

- [General][Changed] TextInput no longer does an extra round trip to native on focus/blur ([e9b4928](https://github.com/facebook/react-native/commit/e9b4928) by [@TheSavior](https://github.com/TheSavior))
- Platform.select now supports native as an option. ([a6fc089](https://github.com/facebook/react-native/commit/a6fc089) by [@koke](https://github.com/koke))

...
```