### PR TITLE
[github] Add stable release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/stable-release-discussion.md
+++ b/.github/ISSUE_TEMPLATE/stable-release-discussion.md
@@ -1,0 +1,13 @@
+---
+name: Stable release discussion
+about: This type of issue is to discuss the current stable release and for community
+  members to request cherry-picks. It is only meant to be used by release maintainers.
+title: V0.X.0 Discussion
+labels: stable, backport request
+assignees: ''
+
+---
+
+Conversations on this thread should be limited to reporting issues that are _new_ in this minor version or requests to cherry-pick bug fixes that _have_ landed in [master](https://github.com/facebook/react-native/commits/master).
+
+In all other cases, please report the issue to http://github.com/facebook/react-native/issues.


### PR DESCRIPTION
Less re-inventing the wheel. We could add a “Known issues and workarounds” list and/or “Known issues without fixes” TODO list. Thoughts?