### PR TITLE
Allow "--verbose" without to explicit boolean flag to enable verbose changelog listings

### DIFF
--- a/scripts/changelog-generator.ts
+++ b/scripts/changelog-generator.ts
@@ -807,6 +807,7 @@ if (!module["parent"]) {
       },
       verbose: {
         alias: "v",
+        boolean: true,
         describe:
           "Verbose listing, includes internal changes as well as public-facing changes",
         demandOption: false,


### PR DESCRIPTION
Yargs isn't set to interpret the --verbose flag as a boolean, meaning  "--verbose true" is required to enable verbose listings instead of just "--verbose". The latter will be accepted, but will somewhat confusingly not enable verbose listings. Tell Yargs the type of the verbose flag is a boolean to support both forms.